### PR TITLE
feat: :sparkles: allow passing through props

### DIFF
--- a/src/Blurhash.svelte
+++ b/src/Blurhash.svelte
@@ -28,5 +28,6 @@
     width={resolutionX}
     height={resolutionY}
     style="width:100%;height:100%"
+    {...$$restProps}
   />
 </div>

--- a/src/BlurhashImage.svelte
+++ b/src/BlurhashImage.svelte
@@ -23,9 +23,9 @@
   {#if hasBeenVisible}
     <div style="position: relative">
       {#if !isFadeIn}
-        <Blurhash {hash} {width} {height} />
+        <Blurhash {hash} {width} {height} {...$$restProps} />
       {:else}
-        <div style="width: {width}px;height: {height}px" />
+        <div style="width: {width}px;height: {height}px" {...$$restProps} />
       {/if}
 
       <Image
@@ -35,6 +35,7 @@
         {width}
         {height}
         {fadeDuration}
+        {...$$restProps}
       />
     </div>
   {/if}

--- a/src/BlurhashPicture.svelte
+++ b/src/BlurhashPicture.svelte
@@ -37,6 +37,7 @@
           {width}
           {height}
           {fadeDuration}
+          {...$$restProps}
         />
       </picture>
     </div>

--- a/src/Image.svelte
+++ b/src/Image.svelte
@@ -26,4 +26,5 @@
   style="position: absolute;top: 0;left: 0;opacity: 0;transition: opacity {fadeDuration}ms;"
   loading="lazy"
   decoding="async"
+  {...$$restProps}
 />


### PR DESCRIPTION
useful for passing through things such as `class` items from imported component. Closes https://github.com/h416/svelte-blurhash/issues/13